### PR TITLE
Fix uberjar

### DIFF
--- a/.clj-kondo/babashka/fs/config.edn
+++ b/.clj-kondo/babashka/fs/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {babashka.fs/with-temp-dir clojure.core/let}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,0 +1,8 @@
+{:hooks
+ {:analyze-call
+  {next.jdbc/with-transaction
+   hooks.com.github.seancorfield.next-jdbc/with-transaction
+   next.jdbc/with-transaction+options
+   hooks.com.github.seancorfield.next-jdbc/with-transaction+options}}
+ :lint-as {next.jdbc/on-connection clojure.core/with-open
+           next.jdbc/on-connection+options clojure.core/with-open}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
@@ -1,0 +1,34 @@
+(ns hooks.com.github.seancorfield.next-jdbc
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-transaction
+  "Expands (with-transaction [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))
+
+(defn with-transaction+options
+  "Expands (with-transaction+options [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/.clj-kondo/com.pitch/uix.core/config.edn
+++ b/.clj-kondo/com.pitch/uix.core/config.edn
@@ -1,0 +1,45 @@
+{:lint-as {uix.core/fn      clojure.core/fn
+           uix.core/defui   clojure.core/defn
+           uix.core/$       hooks.uix/$
+           uix.core/defhook clojure.core/defn}
+ :linters {:uix.core/$-arg-validation
+           {:level :warning}
+
+           :type-mismatch
+           {:level      :warning
+            :namespaces {uix.core {memo                    {:arities {1 {:args [:ifn]
+                                                                         :ret  [:ifn]}
+                                                                      2 {:args [:ifn :ifn]
+                                                                         :ret  [:any]}}}
+                                   use-state               {:arities {1 {:args [:any]
+                                                                         :ret  [:ifn :any]}}}
+                                   use-memo                {:arities {2 {:args [:ifn :seqable]
+                                                                         :ret  [:any]}}}
+                                   use-effect              {:arities {1 {:args [:ifn]
+                                                                         :ret  [:any]}
+                                                                      2 {:args [:ifn :seqable]
+                                                                         :ret  [:any]}}}
+                                   use-layout-effect       {:arities {1 {:args [:ifn]
+                                                                         :ret  [:any]}
+                                                                      2 {:args [:ifn :seqable]
+                                                                         :ret  [:any]}}}
+                                   use-insertion-effect    {:arities {1 {:args [:ifn]
+                                                                         :ret  [:any]}
+                                                                      2 {:args [:ifn :seqable]
+                                                                         :ret  [:any]}}}
+                                   use-sync-external-store {:arities {1 {:args [:ifn :ifn]
+                                                                         :ret  [:any]}}}
+                                   use-callback            {:arities {2 {:args [:ifn :seqable]
+                                                                         :ret  [:ifn]}}}
+                                   use-ref                 {:aritites {1 {:args [:any]
+                                                                          :ret  [:atom]}}}
+                                   use-reducer             {:arities {2 {:args [:ifn :any]
+                                                                         :ret  [:seqable]}
+                                                                      3 {:args [:ifn :any :any]
+                                                                         :ret  [:seqable]}}}
+                                   as-react                {:arities {1 {:args [:ifn]
+                                                                         :ret  [:any]}}}
+                                   start-transition        {:arities {1 {:args [:ifn]
+                                                                         :ret  [:nil]}}}
+                                   lazy                    {:arities {1 {:args [:ifn]
+                                                                         :ret  [:any]}}}}}}}}

--- a/.clj-kondo/com.pitch/uix.core/hooks/uix.clj
+++ b/.clj-kondo/com.pitch/uix.core/hooks/uix.clj
@@ -1,0 +1,10 @@
+(ns hooks.uix
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn $ [{:keys [node]}]
+  (let [[sym _args] (rest (api/sexpr node))]
+    (when-not (or (symbol? sym)
+                  (keyword? sym))
+      (api/reg-finding! (-> (meta node)
+                            (merge {:message "First arg to $ must be a symbol or keyword"
+                                    :type    :uix.core/$-arg-validation}))))))

--- a/.clj-kondo/hiccup/hiccup/config.edn
+++ b/.clj-kondo/hiccup/hiccup/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {hiccup.def/defhtml clojure.core/defn}
+ :hooks {:analyze-call {hiccup.def/defelem hiccup.hooks/defelem}}}

--- a/.clj-kondo/hiccup/hiccup/hiccup/hooks.clj
+++ b/.clj-kondo/hiccup/hiccup/hiccup/hooks.clj
@@ -1,0 +1,38 @@
+(ns hiccup.hooks
+  (:require [clj-kondo.hooks-api :as api]
+            [clojure.set :as set]))
+
+;; See https://github.com/clj-kondo/clj-kondo/blob/master/doc/hooks.md
+
+(defn- parse-defn [elems]
+  (let [[fhead fbody] (split-with #(not (or (api/vector-node? %)
+                                            (api/list-node? %)))
+                                  elems)
+        arities (if (api/vector-node? (first fbody))
+                  (list (api/list-node fbody))
+                  fbody)]
+    [fhead arities]))
+
+(defn- count-args [arity]
+  (let [args (first (api/sexpr arity))]
+    (if (= '& (fnext (reverse args)))
+      true ; unbounded args
+      (count args))))
+
+(defn- dummy-arity [arg-count]
+  (api/list-node
+   (list
+    (api/vector-node
+     (vec (repeat arg-count (api/token-node '_)))))))
+
+(defn defelem [{:keys [node]}]
+  (let [[_ & rest] (:children node)
+        [fhead arities] (parse-defn rest)
+        arg-counts (set (filter number? (map count-args arities)))
+        dummy-arg-counts (set/difference (set (map inc arg-counts)) arg-counts)
+        dummy-arities (for [n dummy-arg-counts] (dummy-arity n))]
+    {:node
+     (api/list-node
+      (list*
+       (api/token-node 'clojure.core/defn)
+       (concat fhead arities dummy-arities)))}))

--- a/.clj-kondo/http-kit/http-kit/config.edn
+++ b/.clj-kondo/http-kit/http-kit/config.edn
@@ -1,0 +1,3 @@
+
+{:hooks
+ {:analyze-call {org.httpkit.server/with-channel httpkit.with-channel/with-channel}}}

--- a/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
+++ b/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,0 +1,16 @@
+(ns httpkit.with-channel
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-channel [{node :node}]
+  (let [[request channel & body] (rest (:children node))]
+    (when-not (and request     channel) (throw (ex-info "No request or channel provided" {})))
+    (when-not (api/token-node? channel) (throw (ex-info "Missing channel argument" {})))
+    (let [new-node
+          (api/list-node
+            (list*
+              (api/token-node 'let)
+              (api/vector-node [channel (api/vector-node [])])
+              request
+              body))]
+
+      {:node new-node})))

--- a/.clj-kondo/metosin/malli/config.edn
+++ b/.clj-kondo/metosin/malli/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {malli.experimental/defn schema.core/defn}
+ :linters {:unresolved-symbol {:exclude [(malli.core/=>)]}}}

--- a/.clj-kondo/potemkin/potemkin/config.edn
+++ b/.clj-kondo/potemkin/potemkin/config.edn
@@ -1,0 +1,62 @@
+{:lint-as {potemkin.collections/compile-if      clojure.core/if
+           potemkin.collections/reify-map-type  clojure.core/reify
+           potemkin.collections/def-map-type    clj-kondo.lint-as/def-catch-all
+           potemkin.collections/def-derived-map clj-kondo.lint-as/def-catch-all
+
+           potemkin.types/reify+                clojure.core/reify
+           potemkin.types/defprotocol+          clojure.core/defprotocol
+           potemkin.types/deftype+              clojure.core/deftype
+           potemkin.types/defrecord+            clojure.core/defrecord
+           potemkin.types/definterface+         clojure.core/defprotocol
+           potemkin.types/extend-protocol+      clojure.core/extend-protocol
+           potemkin.types/def-abstract-type     clj-kondo.lint-as/def-catch-all
+
+           potemkin.utils/doit                  clojure.core/doseq
+           potemkin.utils/doary                 clojure.core/doseq
+           potemkin.utils/condp-case            clojure.core/condp
+           potemkin.utils/fast-bound-fn         clojure.core/bound-fn
+
+           potemkin.walk/prewalk                clojure.walk/prewalk
+           potemkin.walk/postwalk               clojure.walk/postwalk
+           potemkin.walk/walk                   clojure.walk/walk
+
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+           ;;;; top-level from import-vars
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+           ;; Have hooks
+           ;;potemkin/import-fn potemkin.namespaces/import-fn
+           ;;potemkin/import-macro potemkin.namespaces/import-macro
+           ;;potemkin/import-def potemkin.namespaces/import-def
+
+           ;; Internal, not transitive
+           ;;potemkin/unify-gensyms               potemkin.macros/unify-gensyms
+           ;;potemkin/normalize-gensyms           potemkin.macros/normalize-gensyms
+           ;;potemkin/equivalent?                 potemkin.macros/equivalent?
+
+           potemkin/condp-case                  clojure.core/condp
+           potemkin/doit                        potemkin.utils/doit
+           potemkin/doary                       potemkin.utils/doary
+
+           potemkin/def-abstract-type           clj-kondo.lint-as/def-catch-all
+           potemkin/reify+                      clojure.core/reify
+           potemkin/defprotocol+                clojure.core/defprotocol
+           potemkin/deftype+                    clojure.core/deftype
+           potemkin/defrecord+                  clojure.core/defrecord
+           potemkin/definterface+               clojure.core/defprotocol
+           potemkin/extend-protocol+            clojure.core/extend-protocol
+
+           potemkin/reify-map-type              clojure.core/reify
+           potemkin/def-derived-map             clj-kondo.lint-as/def-catch-all
+           potemkin/def-map-type                clj-kondo.lint-as/def-catch-all}
+
+ ;; leave import-vars alone, kondo special-cases it
+ :hooks   {:macroexpand {#_#_potemkin.namespaces/import-vars potemkin.namespaces/import-vars
+                         potemkin.namespaces/import-fn    potemkin.namespaces/import-fn
+                         potemkin.namespaces/import-macro potemkin.namespaces/import-macro
+                         potemkin.namespaces/import-def   potemkin.namespaces/import-def
+
+                         #_#_potemkin/import-vars potemkin.namespaces/import-vars
+                         potemkin/import-fn               potemkin.namespaces/import-fn
+                         potemkin/import-macro            potemkin.namespaces/import-macro
+                         potemkin/import-def              potemkin.namespaces/import-def}}}

--- a/.clj-kondo/potemkin/potemkin/potemkin/namespaces.clj
+++ b/.clj-kondo/potemkin/potemkin/potemkin/namespaces.clj
@@ -1,0 +1,56 @@
+(ns potemkin.namespaces
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn import-macro*
+  ([sym]
+   `(def ~(-> sym name symbol) ~sym))
+  ([sym name]
+   `(def ~name ~sym)))
+
+(defmacro import-fn
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-macro
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-def
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+#_
+(defmacro import-vars
+  "Imports a list of vars from other namespaces."
+  [& syms]
+  (let [unravel (fn unravel [x]
+                  (if (sequential? x)
+                    (->> x
+                         rest
+                         (mapcat unravel)
+                         (map
+                           #(symbol
+                              (str (first x)
+                                   (when-let [n (namespace %)]
+                                     (str "." n)))
+                              (name %))))
+                    [x]))
+        syms (mapcat unravel syms)
+        result `(do
+                  ~@(map
+                      (fn [sym]
+                        (let [vr (resolve sym)
+                              m (meta vr)]
+                          (cond
+                            (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
+                            (:macro m) `(def ~(-> sym name symbol) ~sym)
+                            (:arglists m) `(def ~(-> sym name symbol) ~sym)
+                            :else `(def ~(-> sym name symbol) ~sym))))
+                      syms))]
+    result))

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/build.clj
+++ b/build.clj
@@ -23,14 +23,13 @@
   (b/copy-dir {:src-dirs ["target/release"]
                :target-dir class-dir})
 
-  #_
   (b/compile-clj {:basis @basis
-                  :ns-compile '[backend.main]
-                  :class-dir class-dir})
+                  :class-dir class-dir
+                  :compile-opts {:direct-linking true}})
 
   (b/uber {:class-dir class-dir
            :uber-file uber-file
-           ;; :main 'backend.main
+           :main 'backend.main
            :basis @basis})
 
   (println "Uberjar:" uber-file))

--- a/build.clj
+++ b/build.clj
@@ -20,6 +20,8 @@
 
   ;; Build frontend:
   (shadow/release :app)
+  (b/copy-dir {:src-dirs ["target/release"]
+               :target-dir class-dir})
 
   #_
   (b/compile-clj {:basis @basis

--- a/src/clj/backend/main.clj
+++ b/src/clj/backend/main.clj
@@ -8,7 +8,8 @@
             [integrant.core :as ig]
             [next.jdbc.date-time]
             [reitit.ring.middleware.exception]
-            [ring.adapter.jetty :as jetty]))
+            [ring.adapter.jetty :as jetty])
+  (:gen-class))
 
 (defmethod aero.core/reader 'ig/ref
   [_opts _tag value]


### PR DESCRIPTION
The uberjar build did call shadow-cljs to do a build, but the actual result itself wasn't copied into the class-dir, from which the uberjar contents is made.

Also, the `backend.main` entrypoint didn't work, added `(:gen-class)` and enabled AOT in the build script.
